### PR TITLE
Dockerfile 및 Gradle 설정 파일 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17
+ARG JAR_FILE=build/libs/app.jar
+COPY ${JAR_FILE} ./app.jar
+ENV TZ=Asia/Seoul
+ENTRYPOINT ["java", "-jar", "./app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,10 @@ configurations {
     }
 }
 
+bootJar{
+    archiveFileName = 'app.jar'
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
이 PR은 프로젝트에 Docker 환경을 추가하고, Spring Boot 애플리케이션을 컨테이너화하기 위한 설정을 포함한다.

- Dockerfile 추가: OpenJDK 17을 기반으로 애플리케이션을 컨테이너화할 수 있도록 Dockerfile을 작성하였다.
- build.gradle 설정 업데이트: Spring Boot 3.3.3을 사용하여 애플리케이션을 빌드하며, 'app.jar'로 빌드 아티팩트를 생성하도록 설정하였다.
- 기본적인 Gradle 의존성 및 설정을 포함하였으며, 이후 데이터베이스 설정(JPA 및 MariaDB)은 주석 처리된 상태로 남겨두었다.