### PR TITLE
Spock 프레임워크를 사용한 URI 인코딩 검증 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.3'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'groovy'
 }
 
 group = 'com.example'
@@ -36,6 +37,14 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // spock
+    testImplementation 'org.spockframework:spock-core:2.4-M1-groovy-4.0'
+    testImplementation 'org.spockframework:spock-spring:2.4-M1-groovy-4.0'
+    testImplementation 'org.apache.groovy:groovy-all:4.0.13'
+
+    // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
+    testImplementation('net.bytebuddy:byte-buddy:1.12.10')
 }
 
 tasks.named('test') {

--- a/src/test/groovy/com/example/phamnav/api/service/buildUriByAddressSearchTest.groovy
+++ b/src/test/groovy/com/example/phamnav/api/service/buildUriByAddressSearchTest.groovy
@@ -1,0 +1,30 @@
+package com.example.phamnav.api.service
+
+import spock.lang.Specification
+
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+
+class buildUriByAddressSearchTest extends Specification {
+
+    private KakaoUriBuilderService kakaoUriBuilderService
+
+    def setup(){
+        kakaoUriBuilderService = new KakaoUriBuilderService()
+    }
+
+    def "buildUriByAddressSearch - 한글 파라미터의 경우 정상적으로 인코딩"() {
+        given:
+        String address = "서울 성북구"
+        def charset = StandardCharsets.UTF_8
+
+        when:
+        def uri = kakaoUriBuilderService.buildUriByAddressSearch(address)
+        def decodedResult = URLDecoder.decode(uri.toString(), charset)
+
+        then:
+        decodedResult == "https://dapi.kakao.com/v2/local/search/address.json?query=서울 성북구"
+    }
+
+}


### PR DESCRIPTION
이 PR은 Spock 프레임워크를 사용하여 KakaoUriBuilderService의 URI 인코딩 로직을 검증하는 테스트 코드를 추가한다.

- 한글 주소가 올바르게 인코딩되어 URI로 생성되는지 확인하는 테스트 케이스를 작성함.
- Spock의 간결한 문법을 통해 테스트 코드의 가독성과 유지보수성을 개선함.
- 테스트 결과를 통해 코드의 신뢰성을 높이고, 서비스의 안정성을 강화함.