### PR TITLE
Pharmacy 주소 업데이트 기능 및 Dirty Checking 테스트 추가

### DIFF
--- a/src/main/java/com/example/phamnav/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/com/example/phamnav/pharmacy/entity/Pharmacy.java
@@ -25,4 +25,7 @@ public class Pharmacy {
     private double latitude;
     private double longitude;
 
+    public void changePharmacyAddress(String address){
+        this.pharmacyAddress = address;
+    }
 }

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRepositoryService.java
@@ -1,0 +1,40 @@
+package com.example.phamnav.pharmacy.service;
+
+import com.example.phamnav.pharmacy.entity.Pharmacy;
+import com.example.phamnav.pharmacy.repository.PharmacyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacyRepositoryService {
+    private final PharmacyRepository pharmacyRepository;
+
+    @Transactional
+    public void updateAddress(Long id, String address) {
+        Pharmacy entity = pharmacyRepository.findById(id).orElse(null);
+
+        if (Objects.isNull(entity)) {
+            log.error("[PharmacyRepositoryService updateAddress] not found id : {}", id);
+            return;
+        }
+
+        entity.changePharmacyAddress(address);
+    }
+
+    public void updateAddressWithoutTransaction(Long id, String address) {
+        Pharmacy entity = pharmacyRepository.findById(id).orElse(null);
+
+        if (Objects.isNull(entity)) {
+            log.error("[PharmacyRepositoryService updateAddress] not found id : {}", id);
+            return;
+        }
+
+        entity.changePharmacyAddress(address);
+    }
+}

--- a/src/test/groovy/com/example/phamnav/pharmacy/service/PharmacyRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/example/phamnav/pharmacy/service/PharmacyRepositoryServiceTest.groovy
@@ -1,0 +1,61 @@
+package com.example.phamnav.pharmacy.service
+
+import com.example.phamnav.AbstractIntegrationContainerBaseTest
+import com.example.phamnav.pharmacy.entity.Pharmacy
+import com.example.phamnav.pharmacy.repository.PharmacyRepository
+import org.springframework.beans.factory.annotation.Autowired
+
+class PharmacyRepositoryServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private PharmacyRepositoryService pharmacyRepositoryService
+
+    @Autowired
+    PharmacyRepository pharmacyRepository
+
+    void setup() {
+        pharmacyRepository.deleteAll()
+    }
+
+    def "PharmacyRepository update - dirty checking success"() {
+
+        given:
+        String inputAddress = "서울 특별시 성북구 종암동"
+        String modifiedAddress = "서울 광진구 구의동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .build()
+        when:
+        def entity = pharmacyRepository.save(pharmacy)
+        pharmacyRepositoryService.updateAddress(entity.getId(), modifiedAddress)
+
+        def result = pharmacyRepository.findAll()
+
+        then:
+        result.get(0).getPharmacyAddress() == modifiedAddress
+    }
+
+    def "PharmacyRepository update - dirty checking fail"() {
+
+        given:
+        String inputAddress = "서울 특별시 성북구 종암동"
+        String modifiedAddress = "서울 광진구 구의동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .build()
+        when:
+        def entity = pharmacyRepository.save(pharmacy)
+        pharmacyRepositoryService.updateAddressWithoutTransaction(entity.getId(), modifiedAddress)
+
+        def result = pharmacyRepository.findAll()
+
+        then:
+        result.get(0).getPharmacyAddress() == inputAddress
+    }
+}


### PR DESCRIPTION
이 PR은 Pharmacy 엔티티의 주소 업데이트 기능을 추가하고, Dirty Checking 기능을 테스트하기 위해 다음과 같은 변경사항을 포함한다.

- Pharmacy 엔티티에 주소 변경 메서드 추가: 약국의 주소를 변경할 수 있는 changePharmacyAddress 메서드를 추가한다.
- PharmacyRepositoryService 클래스에 주소 업데이트 메서드 추가: 트랜잭션을 적용한 주소 업데이트 메서드와 트랜잭션 없는 메서드를 구현한다.
- Dirty Checking 테스트 추가: 트랜잭션 적용 유무에 따라 Dirty Checking이 올바르게 동작하는지 검증하는 테스트 코드를 작성한다.