### PR TITLE
JPA Auditing 적용 및 Pharmacy 엔티티의 생성/수정 시간 자동화 구현

### DIFF
--- a/src/main/java/com/example/phamnav/BaseTimeEntity.java
+++ b/src/main/java/com/example/phamnav/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.example.phamnav;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/com/example/phamnav/PhamNavApplication.java
+++ b/src/main/java/com/example/phamnav/PhamNavApplication.java
@@ -2,7 +2,9 @@ package com.example.phamnav;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PhamNavApplication {
 

--- a/src/main/java/com/example/phamnav/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/com/example/phamnav/pharmacy/entity/Pharmacy.java
@@ -1,5 +1,6 @@
 package com.example.phamnav.pharmacy.entity;
 
+import com.example.phamnav.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Pharmacy {
+public class Pharmacy extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/groovy/com/example/phamnav/pharmacy/repository/PharmacyRepositoryTest.groovy
+++ b/src/test/groovy/com/example/phamnav/pharmacy/repository/PharmacyRepositoryTest.groovy
@@ -4,6 +4,8 @@ import com.example.phamnav.AbstractIntegrationContainerBaseTest
 import com.example.phamnav.pharmacy.entity.Pharmacy
 import org.springframework.beans.factory.annotation.Autowired
 
+import java.time.LocalDateTime
+
 class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest {
 
     @Autowired
@@ -57,6 +59,24 @@ class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest {
 
         then:
         result.size() == 1
+    }
 
+    def "BaseTimeEntity 등록"() {
+        given:
+        LocalDateTime now = LocalDateTime.now()
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+
+        def pharmcy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .build()
+        when:
+        pharmacyRepository.save(pharmcy)
+        def result = pharmacyRepository.findAll()
+
+        then:
+        result.get(0).getCreatedDate().isAfter(now)
+        result.get(0).getModifiedDate().isAfter(now)
     }
 }


### PR DESCRIPTION
이 PR은 JPA Auditing 기능을 적용하여 엔티티의 생성 시간과 수정 시간을 자동으로 관리하기 위한 작업을 포함한다.

JPA Auditing 기능 활성화 (@EnableJpaAuditing 어노테이션 추가)

공통 시간 관리 기능을 제공하는 BaseTimeEntity 추상 클래스 추가

Pharmacy 엔티티가 BaseTimeEntity를 상속받아 생성 시간(createdDate)과 수정 시간(modifiedDate)을 자동으로 관리하도록 수정

JPA Auditing 기능이 정상적으로 동작하는지 검증하기 위한 테스트 코드 추가
