### PR TITLE
거리 계산 알고리즘 구현

### DIFF
--- a/src/main/java/com/example/phamnav/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/phamnav/api/dto/DocumentDto.java
@@ -2,10 +2,12 @@ package com.example.phamnav.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class DocumentDto {

--- a/src/main/java/com/example/phamnav/direction/entity/Direction.java
+++ b/src/main/java/com/example/phamnav/direction/entity/Direction.java
@@ -1,0 +1,36 @@
+package com.example.phamnav.direction.entity;
+
+import com.example.phamnav.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity(name = "direction")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Direction extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 고객
+    private String inputAddress;
+    private double inputLatitude;
+    private double inputLongitude;
+
+    // 약국
+    private String targetPharmacyName;
+    private String targetAddress;
+    private double targetLatitude;
+    private double targetLongitude;
+
+    // 고객 주소와 약국 주소 사이의 거리
+    private double distance;
+}

--- a/src/main/java/com/example/phamnav/direction/service/DirectionService.java
+++ b/src/main/java/com/example/phamnav/direction/service/DirectionService.java
@@ -1,0 +1,60 @@
+package com.example.phamnav.direction.service;
+
+import com.example.phamnav.api.dto.DocumentDto;
+import com.example.phamnav.direction.entity.Direction;
+import com.example.phamnav.pharmacy.service.PharmacySearchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DirectionService {
+    private static final int MAX_SEARCH_COUNT = 3; // 약국 최대 검색 갯수
+    private static final double RADIUS_KM = 10.0; // 반경 10 km
+
+    private final PharmacySearchService pharmacySearchService;
+
+    public List<Direction> buildDriectionList(DocumentDto documentDto) {
+        if(Objects.isNull(documentDto)) return Collections.emptyList();
+
+        return pharmacySearchService.searchPharmacyDtoList()
+                .stream().map(pharmacyDto ->
+                        Direction.builder()
+                                .inputAddress(documentDto.getAddressName())
+                                .inputLatitude(documentDto.getLatitude())
+                                .inputLongitude(documentDto.getLongitude())
+                                .targetPharmacyName(pharmacyDto.getPharmacyName())
+                                .targetAddress(pharmacyDto.getPharmacyAddress())
+                                .targetLatitude(pharmacyDto.getLatitude())
+                                .targetLongitude(pharmacyDto.getLongitude())
+                                .distance(
+                                        calculateDistance(documentDto.getLatitude(), documentDto.getLongitude(),
+                                                pharmacyDto.getLatitude(), pharmacyDto.getLongitude())
+                                )
+                                .build())
+                .filter(direction -> direction.getDistance() <= RADIUS_KM)
+                .sorted(Comparator.comparing(Direction::getDistance))
+                .limit(MAX_SEARCH_COUNT)
+                .collect(Collectors.toList());
+
+    }
+
+    // Haversine formula
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        lat1 = Math.toRadians(lat1);
+        lon1 = Math.toRadians(lon1);
+        lat2 = Math.toRadians(lat2);
+        lon2 = Math.toRadians(lon2);
+
+        double earthRadius = 6371; //Kilometers
+        return earthRadius * Math.acos(Math.sin(lat1) * Math.sin(lat2) + Math.cos(lat1) * Math.cos(lat2) * Math.cos(lon1 - lon2));
+    }
+}

--- a/src/main/java/com/example/phamnav/pharmacy/dto/PharmacyDto.java
+++ b/src/main/java/com/example/phamnav/pharmacy/dto/PharmacyDto.java
@@ -1,0 +1,19 @@
+package com.example.phamnav.pharmacy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PharmacyDto {
+    private Long id;
+    private String pharmacyName;
+    private String pharmacyAddress;
+    private double latitude;
+    private double longitude;
+
+}

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
@@ -1,0 +1,38 @@
+package com.example.phamnav.pharmacy.service;
+
+import com.example.phamnav.pharmacy.dto.PharmacyDto;
+import com.example.phamnav.pharmacy.entity.Pharmacy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacySearchService {
+
+    private final PharmacyRepositoryService pharmacyRepositoryService;
+    public List<PharmacyDto> searchPharmacyDtoList() {
+
+        //redis
+
+        //db
+        return pharmacyRepositoryService.findAll()
+                .stream()
+                .map(this::convertToPharmacyDto)
+                .collect(Collectors.toList());
+    }
+
+    private PharmacyDto convertToPharmacyDto(Pharmacy pharmacy) {
+        return PharmacyDto.builder()
+                .id(pharmacy.getId())
+                .pharmacyAddress(pharmacy.getPharmacyAddress())
+                .pharmacyName(pharmacy.getPharmacyName())
+                .latitude(pharmacy.getLatitude())
+                .longitude(pharmacy.getLongitude())
+                .build();
+    }
+}

--- a/src/test/groovy/com/example/phamnav/direction/service/DirectionServiceTest.groovy
+++ b/src/test/groovy/com/example/phamnav/direction/service/DirectionServiceTest.groovy
@@ -1,0 +1,90 @@
+package com.example.phamnav.direction.service
+
+import com.example.phamnav.api.dto.DocumentDto
+import com.example.phamnav.pharmacy.dto.PharmacyDto
+import com.example.phamnav.pharmacy.service.PharmacySearchService
+import spock.lang.Specification
+
+class DirectionServiceTest extends Specification {
+
+    private PharmacySearchService pharmacySearchService = Mock()
+
+    private DirectionService directionService = new DirectionService(pharmacySearchService)
+
+    private List<PharmacyDto> pharmacyList
+
+    def setup() {
+        pharmacyList = new ArrayList<>()
+        pharmacyList.addAll(PharmacyDto.builder()
+                .id(1L)
+                .pharmacyName("돌곶이온누리약국")
+                .pharmacyAddress("주소1")
+                .latitude(37.61040424)
+                .longitude(127.0569046)
+                .build(),
+                PharmacyDto.builder()
+                        .id(2L)
+                        .pharmacyName("호수온누리약국")
+                        .pharmacyAddress("주소2")
+                        .latitude(37.60894036)
+                        .longitude(127.029052)
+                        .build())
+
+    }
+
+    def "buildDirectionList - 결과 값이 거리 순으로 정렬이 되는지 확인"() {
+        given:
+        def addressName = "서울 성북구 종암로10길"
+        double inputLatitude = 37.5960650456809
+        double inputLongitude = 127.037033003036
+
+        def documentD = DocumentDto.builder()
+                .addressName(addressName)
+                .latitude(inputLatitude)
+                .longitude(inputLongitude)
+                .build()
+
+        when:
+
+        pharmacySearchService.searchPharmacyDtoList() >> pharmacyList
+
+        def results = directionService.buildDriectionList(documentD)
+
+        then:
+        results.size() == 2
+        results.get(0).targetPharmacyName == "호수온누리약국"
+        results.get(1).targetPharmacyName == "돌곶이온누리약국"
+    }
+
+    def "buildDirectionList - 정해진 반경 10 km 내에 검색이 되는지 확인"() {
+        given:
+        pharmacyList.add(PharmacyDto.builder()
+                .id(3L)
+                .pharmacyName("경기약국")
+                .pharmacyAddress("주소3")
+                .latitude(37.3825107393401)
+                .longitude(127.236707911313)
+                .build())
+
+        def addressName = "서울 성북구 종암로10길"
+        double inputLatitude = 37.5960650456809
+        double inputLongitude = 127.037033003036
+
+        def documentDto = DocumentDto.builder()
+                .addressName(addressName)
+                .latitude(inputLatitude)
+                .longitude(inputLongitude)
+                .build()
+
+        when:
+
+        pharmacySearchService.searchPharmacyDtoList() >> pharmacyList
+
+        def results = directionService.buildDriectionList(documentDto)
+
+        then:
+        results.size() == 2
+        results.get(0).targetPharmacyName == "호수온누리약국"
+        results.get(1).targetPharmacyName == "돌곶이온누리약국"
+    }
+}


### PR DESCRIPTION
이 PR은 약국 검색 및 거리 계산 기능을 구현한다. 고객의 주소 정보를 바탕으로 약국 데이터를 검색하고, Haversine 공식을 사용해 고객과 약국 간의 거리를 계산하여 가까운 약국을 찾아주는 기능을 포함한다. 추가로, 관련된 DTO 및 엔티티 클래스를 생성하고, 거리 계산 로직에 대한 테스트 코드를 작성했다.