### PR TITLE
Spring Retry 기능 추가 및 테스트 코드 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,15 @@ dependencies {
 
     // 런타임에 클래스 기반 spock mock을 만들기 위해서 필요
     testImplementation('net.bytebuddy:byte-buddy:1.12.10')
+
+    // spring retry
+    implementation 'org.springframework.retry:spring-retry'
+
+    // mockWebServer
+    testImplementation('com.squareup.okhttp3:okhttp:4.11.0')
+    testImplementation('com.squareup.okhttp3:mockwebserver:4.11.0')
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/phamnav/api/service/KakaoAddressSearchService.java
+++ b/src/main/java/com/example/phamnav/api/service/KakaoAddressSearchService.java
@@ -7,6 +7,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.RestTemplate;
@@ -24,6 +27,11 @@ public class KakaoAddressSearchService {
     @Value("${kakao.rest.api.key}")
     private String kakaoRestApiKey;
 
+    @Retryable(
+            value = {RuntimeException.class},
+            maxAttempts = 2,
+            backoff = @Backoff(delay = 2000)
+    )
     public KakaoApiResponseDto requestAddressSearch(String address) {
 
         if(ObjectUtils.isEmpty(address)) return null;
@@ -36,5 +44,11 @@ public class KakaoAddressSearchService {
 
         // kakao api 호출
         return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+
+    @Recover
+    public KakaoApiResponseDto recover(RuntimeException e, String address) {
+        log.error("All the retries failed. address: {}, error : {}", address, e.getMessage());
+        return null;
     }
 }

--- a/src/main/java/com/example/phamnav/config/RetryConfig.java
+++ b/src/main/java/com/example/phamnav/config/RetryConfig.java
@@ -1,0 +1,16 @@
+package com.example.phamnav.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.support.RetryTemplate;
+
+@EnableRetry
+@Configuration
+public class RetryConfig {
+
+//    @Bean
+//    public RetryTemplate retryTemplate() {
+//        return new RetryTemplate();
+//    }
+}

--- a/src/test/groovy/com/example/phamnav/api/service/KakaoAddressSearchServiceRetryTest.groovy
+++ b/src/test/groovy/com/example/phamnav/api/service/KakaoAddressSearchServiceRetryTest.groovy
@@ -1,0 +1,76 @@
+package com.example.phamnav.api.service
+
+import com.example.phamnav.AbstractIntegrationContainerBaseTest
+import com.example.phamnav.api.dto.DocumentDto
+import com.example.phamnav.api.dto.KakaoApiResponseDto
+import com.example.phamnav.api.dto.MetaDto
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.spockframework.spring.SpringBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper
+
+class KakaoAddressSearchServiceRetryTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private KakaoAddressSearchService kakaoAddressSearchService
+
+    @SpringBean
+    private KakaoUriBuilderService kakaoUriBuilderService = Mock()
+
+    private MockWebServer mockWebServer
+
+    private ObjectMapper mapper = new ObjectMapper()
+
+    private String inputAddress = "서울 성북구 종암로 10길"
+
+    def setup() {
+        mockWebServer = new MockWebServer()
+        mockWebServer.start()
+        println mockWebServer.port
+        println mockWebServer.url("/")
+    }
+
+    def cleanup() {
+        mockWebServer.shutdown()
+    }
+
+    def "requestAddressSearch retry success"() {
+        given:
+        def metaDto = new MetaDto(1)
+        def documentDto = DocumentDto.builder()
+                .addressName(inputAddress)
+                .build()
+        def expectedResponse = new KakaoApiResponseDto(metaDto, Arrays.asList(documentDto))
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .setBody(mapper.writeValueAsString(expectedResponse)))
+
+        def kakaoApiResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        kakaoApiResult.getDocumentList().size() == 1
+        kakaoApiResult.getDocumentList().get(0).getAddressName() == inputAddress
+    }
+
+    def "requestAddressSearch retry fail "(){
+        given:
+        def uri = mockWebServer.url("/").uri()
+
+        when:
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+        mockWebServer.enqueue(new MockResponse().setResponseCode(504))
+
+        def result = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        2 * kakaoUriBuilderService.buildUriByAddressSearch(inputAddress) >> uri
+        result == null
+    }
+}


### PR DESCRIPTION
이 PR은 Spring Retry 기능을 추가하여, Kakao API 호출 시 실패할 경우 자동으로 재시도하는 로직을 구현하고, 이를 검증하는 테스트 코드를 작성한다. 해당 기능은 API 호출의 안정성을 높이고, 외부 API 실패로 인한 오류를 최소화하는 것을 목표로 한다.