### PR TITLE
약국 추천 결과 저장 기능 구현

### DIFF
--- a/src/main/java/com/example/phamnav/direction/repository/DirectionRepository.java
+++ b/src/main/java/com/example/phamnav/direction/repository/DirectionRepository.java
@@ -1,0 +1,8 @@
+package com.example.phamnav.direction.repository;
+
+import com.example.phamnav.direction.entity.Direction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DirectionRepository extends JpaRepository<Direction, Long> {
+
+}

--- a/src/main/java/com/example/phamnav/direction/service/DirectionService.java
+++ b/src/main/java/com/example/phamnav/direction/service/DirectionService.java
@@ -2,10 +2,13 @@ package com.example.phamnav.direction.service;
 
 import com.example.phamnav.api.dto.DocumentDto;
 import com.example.phamnav.direction.entity.Direction;
+import com.example.phamnav.direction.repository.DirectionRepository;
 import com.example.phamnav.pharmacy.service.PharmacySearchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -21,7 +24,14 @@ public class DirectionService {
     private static final double RADIUS_KM = 10.0; // 반경 10 km
 
     private final PharmacySearchService pharmacySearchService;
+    private final DirectionRepository directionRepository;
 
+    @Transactional
+    public List<Direction> saveAll(List<Direction> directionList) {
+        if(CollectionUtils.isEmpty(directionList)) return Collections.emptyList();
+        return directionRepository.saveAll(directionList);
+    }
+    
     public List<Direction> buildDriectionList(DocumentDto documentDto) {
         if(Objects.isNull(documentDto)) return Collections.emptyList();
 

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRecommendationService.java
@@ -1,0 +1,40 @@
+package com.example.phamnav.pharmacy.service;
+
+import com.example.phamnav.api.dto.DocumentDto;
+import com.example.phamnav.api.dto.KakaoApiResponseDto;
+import com.example.phamnav.api.service.KakaoAddressSearchService;
+import com.example.phamnav.direction.entity.Direction;
+import com.example.phamnav.direction.service.DirectionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacyRecommendationService {
+
+    private final KakaoAddressSearchService kakaoAddressSearchService;
+    private final DirectionService directionService;
+
+    public void recommendPharmacy(String address) {
+
+        KakaoApiResponseDto kakaoApiResponseDto = kakaoAddressSearchService.requestAddressSearch(address);
+
+            if (Objects.isNull(kakaoApiResponseDto) || CollectionUtils.isEmpty(kakaoApiResponseDto.getDocumentList())) {
+                log.error("[PharmacyRecommendationService] Input address: {}", address);
+            return;
+        }
+
+        DocumentDto documentDto = kakaoApiResponseDto.getDocumentList().get(0);
+
+        List<Direction> directionList = directionService.buildDriectionList(documentDto);
+
+        directionService.saveAll(directionList);
+
+    }
+}

--- a/src/test/groovy/com/example/phamnav/api/service/KakaoAddressSearchServiceTest.groovy
+++ b/src/test/groovy/com/example/phamnav/api/service/KakaoAddressSearchServiceTest.groovy
@@ -1,7 +1,6 @@
 package com.example.phamnav.api.service
 
 import com.example.phamnav.AbstractIntegrationContainerBaseTest
-import com.example.phamnav.api.dto.KakaoApiResponseDto
 import org.springframework.beans.factory.annotation.Autowired
 
 class KakaoAddressSearchServiceTest extends AbstractIntegrationContainerBaseTest {
@@ -33,4 +32,28 @@ class KakaoAddressSearchServiceTest extends AbstractIntegrationContainerBaseTest
         result.documentList.get(0).addressName != null
     }
 
+    def "정상적인 주소를 입력했을 경우, 정상적으로 위도 경도로 변환 된다."() {
+
+        given:
+        boolean actualResult = false
+
+        when:
+        def searchResult = kakaoAddressSearchService.requestAddressSearch(inputAddress)
+
+        then:
+        if(searchResult == null) actualResult = false
+        else actualResult = searchResult.getDocumentList().size() > 0
+
+        actualResult == expectedResult
+
+        where:
+        inputAddress                            | expectedResult
+        "서울 특별시 성북구 종암동"                   | true
+        "서울 성북구 종암동 91"                     | true
+        "서울 대학로"                             | true
+        "서울 성북구 종암동 잘못된 주소"               | false
+        "광진구 구의동 251-45"                     | true
+        "광진구 구의동 251-455555"                 | false
+        ""                                      | false
+    }
 }


### PR DESCRIPTION
이 PR은 약국 추천 시스템에서 추천 결과를 데이터베이스에 저장하는 기능을 구현한다.

- DirectionRepository를 추가하고, DirectionService에 의존성을 주입하여 추천 결과를 저장할 수 있도록 한다.

- PharmacyRecommendationService에서 카카오 API를 통해 받은 주소 데이터를 바탕으로 추천된 약국 리스트를 생성하고, 이를 DirectionService를 통해 저장한다.

- 정상적인 주소와 잘못된 주소 입력 시의 처리를 포함한 테스트 케이스를 추가하고 수정하여 코드의 안정성을 확보한다.