### PR TITLE
카카오 API 통합을 통한 약국 추천 기능 구현

### DIFF
--- a/src/main/java/com/example/phamnav/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/phamnav/api/dto/DocumentDto.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DocumentDto {
 
+    @JsonProperty("place_name")
+    private String placeName;
+
     @JsonProperty("address_name")
     private String addressName;
 
@@ -20,4 +23,8 @@ public class DocumentDto {
 
     @JsonProperty("x")
     private double longitude;
+
+    @JsonProperty("distance")
+    private double distance;
+
 }

--- a/src/main/java/com/example/phamnav/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/example/phamnav/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,38 @@
+package com.example.phamnav.api.service;
+
+import com.example.phamnav.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY = "PM9";
+
+    @Value("${KAKAO.REST.API.KEY}")
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestPharmacyCategorySearch(double latitude, double longitude, double radius) {
+        URI uri = kakaoUriBuilderService.buildUriByCategorySearch(latitude, longitude, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+    }
+}

--- a/src/main/java/com/example/phamnav/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/phamnav/api/service/KakaoUriBuilderService.java
@@ -11,15 +11,33 @@ import java.net.URI;
 public class KakaoUriBuilderService {
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/address.json";
+
     public URI buildUriByAddressSearch(String address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
-
         uriBuilder.queryParam("query", address);
 
         URI uri = uriBuilder.build().encode().toUri();
         log.info("[KakaoUriBuilderService buildUriByAddressSearch] address: {}, uri : {}", address, uri);
 
         return uri;
+    }
 
+    public URI buildUriByCategorySearch(double latitude, double longitude, double radius, String category) {
+
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder uriBUilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+        uriBUilder.queryParam("category_group_code", category);
+        uriBUilder.queryParam("x", longitude);
+        uriBUilder.queryParam("y", latitude);
+        uriBUilder.queryParam("radius", meterRadius);
+        uriBUilder.queryParam("sort", "distance");
+
+        URI uri = uriBUilder.build().encode().toUri();
+
+        log.info("[KakaoAddressSearchService buildUriByCategorySearch] uri: {} ", uri);
+
+        return uri;
     }
 }

--- a/src/main/java/com/example/phamnav/direction/service/DirectionService.java
+++ b/src/main/java/com/example/phamnav/direction/service/DirectionService.java
@@ -1,6 +1,7 @@
 package com.example.phamnav.direction.service;
 
 import com.example.phamnav.api.dto.DocumentDto;
+import com.example.phamnav.api.service.KakaoCategorySearchService;
 import com.example.phamnav.direction.entity.Direction;
 import com.example.phamnav.direction.repository.DirectionRepository;
 import com.example.phamnav.pharmacy.service.PharmacySearchService;
@@ -25,6 +26,7 @@ public class DirectionService {
 
     private final PharmacySearchService pharmacySearchService;
     private final DirectionRepository directionRepository;
+    private final KakaoCategorySearchService kakaoCategorySearchService;
 
     @Transactional
     public List<Direction> saveAll(List<Direction> directionList) {
@@ -55,6 +57,28 @@ public class DirectionService {
                 .limit(MAX_SEARCH_COUNT)
                 .collect(Collectors.toList());
 
+    }
+
+    // pharmacy search by category kakao api
+    public List<Direction> buildDirectionListByCategoryApi(DocumentDto inputDocumentDto) {
+        if(Objects.isNull(inputDocumentDto)) return Collections.emptyList();
+
+        return kakaoCategorySearchService
+                .requestPharmacyCategorySearch(inputDocumentDto.getLatitude(), inputDocumentDto.getLongitude(), RADIUS_KM)
+                .getDocumentList()
+                .stream().map(resultDocumentDto ->
+                        Direction.builder()
+                                .inputAddress(inputDocumentDto.getAddressName())
+                                .inputLatitude(inputDocumentDto.getLatitude())
+                                .inputLongitude(inputDocumentDto.getLongitude())
+                                .targetPharmacyName(resultDocumentDto.getPlaceName())
+                                .targetAddress(resultDocumentDto.getAddressName())
+                                .targetLatitude(resultDocumentDto.getLatitude())
+                                .targetLongitude(resultDocumentDto.getLongitude())
+                                .distance(resultDocumentDto.getDistance() * 0.001) // km 단위
+                                .build())
+                .limit(MAX_SEARCH_COUNT)
+                .collect(Collectors.toList());
     }
 
     // Haversine formula

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRecommendationService.java
@@ -32,9 +32,9 @@ public class PharmacyRecommendationService {
 
         DocumentDto documentDto = kakaoApiResponseDto.getDocumentList().get(0);
 
-        List<Direction> directionList = directionService.buildDriectionList(documentDto);
-
-        directionService.saveAll(directionList);
+//        List<Direction> directionList = directionService.buildDriectionList(documentDto);
+        List<Direction> directionsList1 = directionService.buildDirectionListByCategoryApi(documentDto);
+        directionService.saveAll(directionsList1);
 
     }
 }


### PR DESCRIPTION
이 PR은 카카오 API를 통합하여 약국 추천 기능을 구현한다. 이를 통해 실시간으로 업데이트된 데이터를 사용하여 사용자에게 더 정확한 약국 정보를 제공할 수 있게 된다.