### PR TITLE
카카오 우편번호 서비스 통합 및 주소 자동 기입 기능 추가

### DIFF
--- a/src/main/resources/templates/main.hbs
+++ b/src/main/resources/templates/main.hbs
@@ -16,7 +16,7 @@
             <form action="/search" method="post">
                 <div class="mb-3">
                     <label for="address" class="form-label">주소를 입력하시면 주소 기준으로 가까운 약국의 위치 최대 3곳 추천드립니다.</label>
-                    <input type="text" class="form-control" id="address" name="address"
+                    <input type="text" class="form-control" id="address_kakao" name="address"
                            placeholder="주소(지번 또는 도로명)를 입력하세요. ex) 서울특별시 성북구 종암로 9길">
                 </div>
                 <button type="submit" class="btn btn-primary" id="btn-save">Search</button>
@@ -29,5 +29,20 @@
 <script src="/js/lib/jquery.min.js"></script>
 <script src="/js/lib/bootstrap.min.js"></script>
 
+<!-- Kakao 우편번호 서비스 -->
+<!-- https://postcode.map.daum.net/guide -->
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script>
+    window.onload = function() {
+        document.getElementById("address_kakao").addEventListener("click", function(){
+
+            new daum.Postcode({
+                oncomplete: function(data) {
+                    document.getElementById("address_kakao").value = data.address;
+                }
+            }).open();
+        });
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
이 PR은 주소 입력을 개선하기 위해 카카오 우편번호 서비스를 프로젝트에 통합한다.

- 사용자가 주소 입력란을 클릭하면 카카오 우편번호 팝업이 나타나고, 팝업에서 선택한 주소가 자동으로 입력란에 기입되는 기능을 추가한다.