### PR TITLE
메인화면, 결과화면 구현

### DIFF
--- a/src/main/java/com/example/phamnav/direction/controller/FormController.java
+++ b/src/main/java/com/example/phamnav/direction/controller/FormController.java
@@ -1,15 +1,30 @@
 package com.example.phamnav.direction.controller;
 
+import com.example.phamnav.dto.InputDto;
+import com.example.phamnav.pharmacy.service.PharmacyRecommendationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 @RequiredArgsConstructor
 public class FormController {
+    private final PharmacyRecommendationService pharmacyRecommendationService;
 
     @GetMapping("/")
     public String main() {
         return "main";
+    }
+
+    @PostMapping("/search")
+    public ModelAndView postDirection(@ModelAttribute InputDto inputDto) {
+        ModelAndView modelAndView = new ModelAndView();
+        modelAndView.setViewName("output");
+        modelAndView.addObject("outputFormList",
+                pharmacyRecommendationService.recommendPharmacyList(inputDto.getAddress()));
+        return modelAndView;
     }
 }

--- a/src/main/java/com/example/phamnav/dto/InputDto.java
+++ b/src/main/java/com/example/phamnav/dto/InputDto.java
@@ -1,0 +1,11 @@
+package com.example.phamnav.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InputDto {
+    private String address;
+
+}

--- a/src/main/java/com/example/phamnav/dto/OutputDto.java
+++ b/src/main/java/com/example/phamnav/dto/OutputDto.java
@@ -1,0 +1,15 @@
+package com.example.phamnav.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OutputDto {
+
+    private String pharmacyName;
+    private String pharmacyAddress;
+    private String directionUrl;
+    private String roadViewUrl;
+    private String distance;
+}

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacyRecommendationService.java
@@ -5,13 +5,16 @@ import com.example.phamnav.api.dto.KakaoApiResponseDto;
 import com.example.phamnav.api.service.KakaoAddressSearchService;
 import com.example.phamnav.direction.entity.Direction;
 import com.example.phamnav.direction.service.DirectionService;
+import com.example.phamnav.dto.OutputDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -21,20 +24,35 @@ public class PharmacyRecommendationService {
     private final KakaoAddressSearchService kakaoAddressSearchService;
     private final DirectionService directionService;
 
-    public void recommendPharmacy(String address) {
+    public List<OutputDto> recommendPharmacyList(String address) {
 
         KakaoApiResponseDto kakaoApiResponseDto = kakaoAddressSearchService.requestAddressSearch(address);
 
             if (Objects.isNull(kakaoApiResponseDto) || CollectionUtils.isEmpty(kakaoApiResponseDto.getDocumentList())) {
                 log.error("[PharmacyRecommendationService] Input address: {}", address);
-            return;
+            return Collections.emptyList();
         }
 
         DocumentDto documentDto = kakaoApiResponseDto.getDocumentList().get(0);
+        // 공공기관 약국 데이터
+        List<Direction> directionList = directionService.buildDriectionList(documentDto);
 
-//        List<Direction> directionList = directionService.buildDriectionList(documentDto);
-        List<Direction> directionsList1 = directionService.buildDirectionListByCategoryApi(documentDto);
-        directionService.saveAll(directionsList1);
+        // kakao api
+//        List<Direction> directionsList1 = directionService.buildDirectionListByCategoryApi(documentDto);
 
+        return directionService.saveAll(directionList)
+                .stream()
+                .map(this::convertToOutputDto)
+                .collect(Collectors.toList());
     }
+    private OutputDto convertToOutputDto(Direction direction) {
+        return OutputDto.builder()
+                .pharmacyAddress(direction.getTargetPharmacyName())
+                .pharmacyAddress(direction.getTargetAddress())
+                .directionUrl("todo") //TODO
+                .roadViewUrl("todo")
+                .distance(String.format("%.2f", direction.getDistance()))
+                .build();
+    }
+
 }

--- a/src/main/resources/templates/output.hbs
+++ b/src/main/resources/templates/output.hbs
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Pharmacy Recommendation System</title>
+    <!--부트스트랩 css 추가-->
+    <link rel="stylesheet" href="/css/lib/bootstrap.min.css">
+
+    <style>
+        .grid-image, .h2-title{
+            display: flex;
+            justify-content: center;
+        }
+        img {
+            margin: 0 0 5px;
+            width: 70%;
+            height: 550px;
+        }
+    </style>
+</head>
+<body>
+<div>
+    <h2 class="h2-title">Pharmacy Recommendation Results</h2>
+</div>
+
+<table class="table table-hover">
+    <tr>
+        <th>약국명</th>
+        <th>약국 주소</th>
+        <th>거리</th>
+        <th>길안내 링크</th>
+        <th>로드뷰 링크</th>
+    </tr>
+    {{#each outputFormList}}
+        <tr>
+            <td>{{pharmacyName}}</td>
+            <td>{{pharmacyAddress}}</td>
+            <td>{{distance}}</td>
+            <td><a href="{{directionUrl}}">{{directionUrl}}</a></td>
+            <td><a href="{{roadViewUrl}}">{{roadViewUrl}}</a></td>
+        </tr>
+    {{/each}}
+</table>
+<div class="grid-image">
+    <img src="/images/kakao.png" alt="kakao" class="img-responsive img-rounded">
+</div>
+<script src="/js/lib/jquery.min.js"></script>
+<script src="/js/lib/bootstrap.min.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
이 PR은 사용자가 입력한 주소를 기반으로 약국을 추천하고, 그 결과를 화면에 시각적으로 표시하는 기능을 구현한다.

DTO 추가: 입력된 주소를 처리하기 위한 InputDto와 약국 추천 결과를 담는 OutputDto를 추가하여, 데이터 전달을 명확하고 일관되게 처리한다.

컨트롤러 수정: 주소 검색을 처리하는 /search 엔드포인트를 추가하고, 검색 결과를 반환하는 기능을 구현한다.

서비스 수정: PharmacyRecommendationService에서 주소를 기반으로 약국을 추천하고, 결과를 리스트 형태로 반환하는 로직을 추가한다.

결과 화면 구현: 추천된 약국 리스트를 시각적으로 표시하기 위한 Handlebars 템플릿을 추가하여, 사용자가 검색 결과를 확인할 수 있도록 한다.