### PR TITLE
redis를 이용한 성능 개선

### DIFF
--- a/src/main/java/com/example/phamnav/config/ObjectMapperConfig.java
+++ b/src/main/java/com/example/phamnav/config/ObjectMapperConfig.java
@@ -1,0 +1,14 @@
+package com.example.phamnav.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/com/example/phamnav/pharmacy/cache/PharmacyRedisTemplateService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/cache/PharmacyRedisTemplateService.java
@@ -1,0 +1,81 @@
+package com.example.phamnav.pharmacy.cache;
+
+import com.example.phamnav.pharmacy.dto.PharmacyDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacyRedisTemplateService {
+
+    private static final String CACHE_KEY = "PHARMACY";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private HashOperations<String, String, String> hashOperations;
+
+    @PostConstruct
+    public void init() {
+        this.hashOperations = redisTemplate.opsForHash();
+
+    }
+
+    public void save(PharmacyDto pharmacyDto) {
+        if(Objects.isNull(pharmacyDto) || Objects.isNull(pharmacyDto.getId())) {
+            log.error("Required Values must not be null");
+            return;
+        }
+
+        try {
+            hashOperations.put(CACHE_KEY,
+                    pharmacyDto.getId().toString(),
+                    serializePharmacyDto(pharmacyDto));
+            log.info("[PharmacyRedisTemplateService save success] id: {}", pharmacyDto.getId());
+        } catch (Exception e) {
+            log.error("[PharmacyRedisTemplateService save error] {}", e.getMessage());
+        }
+    }
+
+    public List<PharmacyDto> findAll() {
+
+        try {
+            List<PharmacyDto> list = new ArrayList<>();
+            for (String value : hashOperations.entries(CACHE_KEY).values()) {
+                PharmacyDto pharmacyDto = deserializePharmacyDto(value);
+                list.add(pharmacyDto);
+            }
+            return list;
+
+        } catch (Exception e) {
+            log.error("[PharmacyRedisTemplateService findAll error]: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    public void delete(Long id) {
+        hashOperations.delete(CACHE_KEY, String.valueOf(id));
+        log.info("[PharmacyRedisTemplateService delete]: {} ", id);
+    }
+
+    private String serializePharmacyDto(PharmacyDto pharmacyDto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(pharmacyDto);
+    }
+
+    private PharmacyDto deserializePharmacyDto(String value) throws JsonProcessingException {
+        return objectMapper.readValue(value, PharmacyDto.class);
+    }
+}
+

--- a/src/main/java/com/example/phamnav/pharmacy/controller/PharmacyController.java
+++ b/src/main/java/com/example/phamnav/pharmacy/controller/PharmacyController.java
@@ -1,0 +1,40 @@
+package com.example.phamnav.pharmacy.controller;
+
+import com.example.phamnav.pharmacy.cache.PharmacyRedisTemplateService;
+import com.example.phamnav.pharmacy.dto.PharmacyDto;
+import com.example.phamnav.pharmacy.service.PharmacyRepositoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PharmacyController {
+
+    private final PharmacyRepositoryService pharmacyRepositoryService;
+    private final PharmacyRedisTemplateService pharmacyRedisTemplateService;
+
+    // 데이터 초기 셋팅을 위한 임시 메서드
+    @GetMapping("/redis/save")
+    public String save() {
+
+        List<PharmacyDto> pharmacyDtoList = pharmacyRepositoryService.findAll()
+                .stream().map(pharmacy -> PharmacyDto.builder()
+                        .id(pharmacy.getId())
+                        .pharmacyName(pharmacy.getPharmacyName())
+                        .pharmacyAddress(pharmacy.getPharmacyAddress())
+                        .latitude(pharmacy.getLatitude())
+                        .longitude(pharmacy.getLongitude())
+                        .build())
+                .collect(Collectors.toList());
+
+        pharmacyDtoList.forEach(pharmacyRedisTemplateService::save);
+
+        return "success";
+    }
+}

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
@@ -1,5 +1,6 @@
 package com.example.phamnav.pharmacy.service;
 
+import com.example.phamnav.pharmacy.cache.PharmacyRedisTemplateService;
 import com.example.phamnav.pharmacy.dto.PharmacyDto;
 import com.example.phamnav.pharmacy.entity.Pharmacy;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +16,14 @@ import java.util.stream.Collectors;
 public class PharmacySearchService {
 
     private final PharmacyRepositoryService pharmacyRepositoryService;
+
+    private final PharmacyRedisTemplateService pharmacyRedisTemplateService;
+
     public List<PharmacyDto> searchPharmacyDtoList() {
 
         //redis
+         List<PharmacyDto> pharmacyDtoList = pharmacyRedisTemplateService.findAll();
+        if(!pharmacyDtoList.isEmpty()) return pharmacyDtoList;
 
         //db
         return pharmacyRepositoryService.findAll()


### PR DESCRIPTION
이 PR은 약국 데이터를 Redis에 캐싱하여 조회 성능을 최적화하고, 캐시 미스 시 DB를 조회하는 로직을 추가한다.

-Redis를 이용한 약국 데이터 캐싱 기능 추가
-PharmacySearchService에 캐시 우선 조회 적용
-Redis와 DB 데이터 동기화를 위한 컨트롤러 메서드 추가
-ObjectMapper 빈 등록으로 데이터 직렬화/역직렬화 처리