### PR TITLE
Redis 캐시 및 통합 테스트 추가

### DIFF
--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
@@ -23,7 +23,10 @@ public class PharmacySearchService {
 
         //redis
          List<PharmacyDto> pharmacyDtoList = pharmacyRedisTemplateService.findAll();
-        if(!pharmacyDtoList.isEmpty()) return pharmacyDtoList;
+        if(!pharmacyDtoList.isEmpty()){
+            log.info("redis findAll success!");
+            return pharmacyDtoList;
+        }
 
         //db
         return pharmacyRepositoryService.findAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ spring:
     port: 6379
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     show-sql: true
 
 pharmacy:

--- a/src/test/groovy/com/example/phamnav/pharmacy/cache/PharmacyRedisTemplateServiceTest.groovy
+++ b/src/test/groovy/com/example/phamnav/pharmacy/cache/PharmacyRedisTemplateServiceTest.groovy
@@ -1,0 +1,74 @@
+package com.example.phamnav.pharmacy.cache
+
+import com.example.phamnav.AbstractIntegrationContainerBaseTest
+import com.example.phamnav.pharmacy.dto.PharmacyDto
+import org.springframework.beans.factory.annotation.Autowired
+
+class PharmacyRedisTemplateServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private PharmacyRedisTemplateService pharmacyRedisTemplateService
+
+    def setup() {
+        pharmacyRedisTemplateService.findAll()
+        .forEach(dto -> {
+            pharmacyRedisTemplateService.delete(dto.getId())
+        })
+    }
+
+    def "save success"() {
+        given:
+        String pharmacyName = "name"
+        String pharmacyAddress = "address"
+        PharmacyDto dto =
+                PharmacyDto.builder()
+                        .id(1L)
+                        .pharmacyName(pharmacyName)
+                        .pharmacyAddress(pharmacyAddress)
+                        .build()
+
+        when:
+        pharmacyRedisTemplateService.save(dto)
+        List<PharmacyDto> result = pharmacyRedisTemplateService.findAll()
+
+        then:
+        result.size() == 1
+        result.get(0).id == 1L
+        result.get(0).pharmacyName == pharmacyName
+        result.get(0).pharmacyAddress == pharmacyAddress
+    }
+
+    def "success fail"() {
+        given:
+        PharmacyDto dto =
+                PharmacyDto.builder()
+                        .build()
+
+        when:
+        pharmacyRedisTemplateService.save(dto)
+        List<PharmacyDto> result = pharmacyRedisTemplateService.findAll()
+
+        then:
+        result.size() == 0
+    }
+
+    def "delete"() {
+        given:
+        String pharmacyName = "name"
+        String pharmacyAddress = "address"
+        PharmacyDto dto =
+                PharmacyDto.builder()
+                        .id(1L)
+                        .pharmacyName(pharmacyName)
+                        .pharmacyAddress(pharmacyAddress)
+                        .build()
+
+        when:
+        pharmacyRedisTemplateService.save(dto)
+        pharmacyRedisTemplateService.delete(dto.getId())
+        def result = pharmacyRedisTemplateService.findAll()
+
+        then:
+        result.size() == 0
+    }
+}

--- a/src/test/groovy/com/example/phamnav/pharmacy/service/PharmacySearchServiceTest.groovy
+++ b/src/test/groovy/com/example/phamnav/pharmacy/service/PharmacySearchServiceTest.groovy
@@ -1,0 +1,46 @@
+package com.example.phamnav.pharmacy.service
+
+import com.example.phamnav.pharmacy.cache.PharmacyRedisTemplateService
+import com.example.phamnav.pharmacy.entity.Pharmacy
+import com.google.common.collect.Lists
+import spock.lang.Specification
+
+class PharmacySearchServiceTest extends Specification {
+    private PharmacySearchService pharmacySearchService
+
+    private PharmacyRepositoryService pharmacyRepositoryService = Mock()
+    private PharmacyRedisTemplateService pharmacyRedisTemplateService = Mock()
+
+    private List<Pharmacy> pharmacyList
+
+    def setup() {
+        pharmacySearchService = new PharmacySearchService(pharmacyRepositoryService, pharmacyRedisTemplateService)
+
+        pharmacyList = Lists.newArrayList(
+                Pharmacy.builder()
+                        .id(1L)
+                        .pharmacyName("호수온누리약국")
+                        .latitude(37.60894036)
+                        .longitude(127.029052)
+                        .build(),
+                Pharmacy.builder()
+                        .id(2L)
+                        .pharmacyName("돌곶이온누리약국")
+                        .latitude(37.61040424)
+                        .longitude(127.0569046)
+                        .build()
+        )
+    }
+
+    def "레디스 장애시 DB를 이용 하여 약국 데이터 조회"() {
+
+        when:
+        pharmacyRedisTemplateService.findAll() >> []
+        pharmacyRepositoryService.findAll() >> pharmacyList
+
+        def result = pharmacySearchService.searchPharmacyDtoList()
+
+        then:
+        result.size() == 2
+    }
+}


### PR DESCRIPTION
이 PR은 Redis 캐시 기능과 관련된 테스트를 추가하고, Redis 장애 시 DB로부터 데이터를 조회하는 로직을 검증하는 내용을 포함한다.

**Redis 통합 테스트 추가**
- PharmacyRedisTemplateServiceTest를 통해 Redis에 데이터를 저장, 조회, 삭제하는 테스트를 추가하여 Redis 캐시 기능을 검증.
- Redis 서버와의 실제 통신을 기반으로 Redis의 동작을 확인.

**PharmacySearchService 테스트**
- PharmacySearchServiceTest에서 Redis 장애 시 DB에서 데이터를 조회하는 로직을 검증하는 테스트를 추가.
- Redis에 데이터가 없을 경우 DB로 fallback하는 전략이 정상적으로 동작하는지 확인.