### PR TITLE
EC2 고정 IP 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,4 +62,4 @@ spring:
 pharmacy:
   recommendation:
     base:
-      url: http://localhost/dir/
+      url: http://13.125.188.32/dir/


### PR DESCRIPTION
이 PR은 운영 환경에서 약국 추천 서비스가 EC2 고정 IP를 통해 접근할 수 있도록 application.yml 파일에 EC2의 고정 IP를 설정한다.