### PR TITLE
Redis vs DB 조회 성능 비교 분석

### DIFF
--- a/src/main/java/com/example/phamnav/pharmacy/cache/PharmacyRedisTemplateService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/cache/PharmacyRedisTemplateService.java
@@ -10,10 +10,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -46,6 +43,31 @@ public class PharmacyRedisTemplateService {
             log.info("[PharmacyRedisTemplateService save success] id: {}", pharmacyDto.getId());
         } catch (Exception e) {
             log.error("[PharmacyRedisTemplateService save error] {}", e.getMessage());
+        }
+    }
+
+    public void saveAll(List<PharmacyDto> pharmacyDtoList) {
+        if (pharmacyDtoList == null || pharmacyDtoList.isEmpty()) {
+            log.warn("[PharmacyRedisTemplateService saveAll] Empty list provided");
+            return;
+        }
+
+        try {
+            Map<String, String> pharmacyMap = new HashMap<>();
+            for (PharmacyDto pharmacyDto : pharmacyDtoList) {
+                String jsonString = objectMapper.writeValueAsString(pharmacyDto);
+                pharmacyMap.put(pharmacyDto.getId().toString(), jsonString);
+            }
+
+            hashOperations.putAll(CACHE_KEY, pharmacyMap);
+
+            log.info("[PharmacyRedisTemplateService saveAll success] {} items saved", pharmacyDtoList.size());
+
+            // 저장 후 데이터 확인
+            long savedCount = hashOperations.size(CACHE_KEY);
+            log.info("[PharmacyRedisTemplateService saveAll] Total items in Redis: {}", savedCount);
+        } catch (JsonProcessingException e) {
+            log.error("[PharmacyRedisTemplateService saveAll error] {}", e.getMessage());
         }
     }
 

--- a/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
+++ b/src/main/java/com/example/phamnav/pharmacy/service/PharmacySearchService.java
@@ -2,7 +2,6 @@ package com.example.phamnav.pharmacy.service;
 
 import com.example.phamnav.pharmacy.cache.PharmacyRedisTemplateService;
 import com.example.phamnav.pharmacy.dto.PharmacyDto;
-import com.example.phamnav.kafka.service.PharmacyProducer;
 import com.example.phamnav.pharmacy.entity.Pharmacy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,23 +19,44 @@ public class PharmacySearchService {
     private final PharmacyRedisTemplateService pharmacyRedisTemplateService;
 
     public List<PharmacyDto> searchPharmacyDtoList() {
-        // Redis에서 데이터 조회
-        List<PharmacyDto> pharmacyDtoList = pharmacyRedisTemplateService.findAll();
-        if(!pharmacyDtoList.isEmpty()){
-            log.info("Redis findAll success!");
+        long startRequestTime = System.currentTimeMillis();
+
+        try {
+            // Redis에서 데이터 조회 시간 측정
+            long startRedisTime = System.currentTimeMillis();
+            List<PharmacyDto> pharmacyDtoList = pharmacyRedisTemplateService.findAll();
+            long endRedisTime = System.currentTimeMillis();
+            log.info("레디스 조회 시간: {} ms, 조회된 항목 수: {}", endRedisTime - startRedisTime, pharmacyDtoList.size());
+
+            if (!pharmacyDtoList.isEmpty()) {
+                log.info("Redis findAll success!");
+                return pharmacyDtoList;
+            }
+
+            // DB에서 데이터 조회 시간 측정
+            long startDbTime = System.currentTimeMillis();
+            List<Pharmacy> pharmacyList = pharmacyRepositoryService.findAll();
+            long endDbTime = System.currentTimeMillis();
+            log.info("DB 조회 시간: {} ms, 조회된 항목 수: {}", endDbTime - startDbTime, pharmacyList.size());
+
+            pharmacyDtoList = pharmacyList.stream()
+                    .map(this::convertToPharmacyDto)
+                    .collect(Collectors.toList());
+
+            // Redis에 데이터 저장 시간 측정
+            long startRedisSaveTime = System.currentTimeMillis();
+            pharmacyRedisTemplateService.saveAll(pharmacyDtoList);
+            long endRedisSaveTime = System.currentTimeMillis();
+            log.info("Redis 저장 시간: {} ms, 저장된 항목 수: {}", endRedisSaveTime - startRedisSaveTime, pharmacyDtoList.size());
+
             return pharmacyDtoList;
+        } catch (Exception e) {
+            log.error("데이터 조회 중 오류 발생", e);
+            throw e;
+        } finally {
+            long endRequestTime = System.currentTimeMillis();
+            log.info("전체 요청 처리 시간: {} ms", endRequestTime - startRequestTime);
         }
-
-        // DB에서 데이터 조회
-        pharmacyDtoList = pharmacyRepositoryService.findAll()
-                .stream()
-                .map(this::convertToPharmacyDto)
-                .collect(Collectors.toList());
-
-        // Redis에 데이터 저장
-        pharmacyDtoList.forEach(pharmacyRedisTemplateService::save);
-
-        return pharmacyDtoList;
     }
 
     private PharmacyDto convertToPharmacyDto(Pharmacy pharmacy) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,12 +65,9 @@ pharmacy:
 
 logging:
   level:
+    root: INFO
     com.example.phamnav: DEBUG
-    org:
-      springframework:
-        data:
-          redis: DEBUG
-          kafka: DEBUG
+    org.springframework.data.redis: DEBUG
 
 ---
 spring:


### PR DESCRIPTION
이 PR은 Redis 일괄 저장 기능 추가 및 성능 측정 로직을 개선한다.

- PharmacyRedisTemplateService에 일괄 저장 메소드 saveAll을 추가하여 여러 약국 데이터를 한 번에 Redis에 저장할 수 있도록 변경한다.
- 성능 측정을 위해 PharmacySearchService에서 Redis 및 DB 조회와 저장 시 걸리는 시간을 로그로 기록하는 기능을 추가한다.
- 로그 출력을 세분화하여 성능 문제를 식별하고, 저장된 항목의 수를 추적할 수 있도록 개선한다.