### PR TITLE
API 데이터를 Kafka를 통해 DB와 Redis에 저장하도록 개선

### DIFF
--- a/src/main/java/com/example/phamnav/kafka/service/PharmacyProducer.java
+++ b/src/main/java/com/example/phamnav/kafka/service/PharmacyProducer.java
@@ -1,72 +1,28 @@
 package com.example.phamnav.kafka.service;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.example.phamnav.direction.entity.Direction;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.redis.core.StringRedisTemplate;
-
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
 
 @Service
+@RequiredArgsConstructor
 public class PharmacyProducer {
 
     private static final Logger log = LoggerFactory.getLogger(PharmacyProducer.class);
     private final KafkaTemplate<String, String> kafkaTemplate;
-    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
 
-    @Value("${pharmacy.csv.filepath}")
-    private String csvFilePath;
-
-    public PharmacyProducer(KafkaTemplate<String, String> kafkaTemplate, StringRedisTemplate redisTemplate) {
-        this.kafkaTemplate = kafkaTemplate;
-        this.redisTemplate = redisTemplate;
-    }
-
-    public void sendMessage(String message) {
-        kafkaTemplate.send("pharmacy-data", message)
-                .addCallback(
-                        result -> log.info("Message sent successfully: {}", message),
-                        ex -> log.error("Failed to send message: {}", message, ex)
-                );
-    }
-
-    public int sendPharmacyDataFromCsv() {
-        int count = 0;
-        try (BufferedReader br = new BufferedReader(new FileReader(csvFilePath))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                sendMessage(line);
-                count++;
-                if (count % 100 == 0) {
-                    log.info("Sent {} messages to Kafka", count);
-                }
-            }
-            log.info("Total {} messages sent to Kafka", count);
-        } catch (IOException e) {
-            log.error("Error reading CSV file: {}", e.getMessage());
+    public void sendPharmacyData(Direction direction) {
+        try {
+            String pharmacyData = objectMapper.writeValueAsString(direction);
+            kafkaTemplate.send("pharmacy-topic", pharmacyData);
+            log.info("Pharmacy data sent to Kafka: {}", pharmacyData);
+        } catch (Exception e) {
+            log.error("Error sending pharmacy data to Kafka", e);
         }
-        return count;
-    }
-
-    public int sendPharmacyDataToRedis() {
-        int count = 0;
-        try (BufferedReader br = new BufferedReader(new FileReader(csvFilePath))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                redisTemplate.opsForValue().set("pharmacy:" + count, line);
-                count++;
-                if (count % 100 == 0) {
-                    log.info("Sent {} messages to Redis", count);
-                }
-            }
-            log.info("Total {} messages sent to Redis", count);
-        } catch (IOException e) {
-            log.error("Error reading CSV file: {}", e.getMessage());
-        }
-        return count;
     }
 }


### PR DESCRIPTION
### API에서 받은 약국 데이터를 Kafka를 통해 처리하여 DB와 Redis에 저장하는 기능을 구현함.

#### 주요 변경 사항
1. PharmacyProducer 수정: API에서 받은 약국 정보를 Kafka로 전송하는 기능 추가
2. PharmacyConsumer 수정: Kafka에서 약국 정보를 받아 DB와 Redis에 저장하는 로직 구현
3. PharmacyRecommendationService 수정: 약국 추천 시 API 데이터를 Kafka로 전송하는 로직 추가